### PR TITLE
Spark CSV Read: Customisable delimiter and header

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -3,19 +3,37 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
 extension-pkg-whitelist=
 
-# Add files or directories to the blacklist. They should be base names, not
-# paths.
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
+
+# Files or directories to be skipped. They should be base names, not paths.
 ignore=CVS
 
-# Add files or directories matching the regex patterns to the blacklist. The
-# regex matches against base names, not paths.
-ignore-patterns=
+# Add files or directories matching the regex patterns to the ignore-list. The
+# regex matches against paths and can be in Posix or Windows format.
+ignore-paths=
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths. The default value ignores emacs file
+# locks
+ignore-patterns=^\.#
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-init-hook=('import sys; sys.path.append("src/");')
+init-hook='import sys; sys.path.append("src");'
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use.
@@ -33,8 +51,12 @@ load-plugins=
 # Pickle collected data for later comparisons.
 persistent=yes
 
-# Specify a configuration file.
-#rcfile=
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.10
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.
@@ -48,97 +70,27 @@ unsafe-load-any-extension=no
 [MESSAGES CONTROL]
 
 # Only show warnings with the listed confidence levels. Leave empty to show
-# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
 confidence=
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
 # file where it should appear only once). You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
+# disable everything first and then re-enable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        long-suffix,
-        old-ne-operator,
-        old-octal-literal,
-        import-star-module-level,
-        non-ascii-bytes-literal,
-        raw-checker-failed,
+disable=raw-checker-failed,
         bad-inline-option,
         locally-disabled,
         file-ignored,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
-        use-symbolic-message-instead,
-        apply-builtin,
-        basestring-builtin,
-        buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        file-builtin,
-        long-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        old-division,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        raising-string,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
-        eq-without-hash,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        deprecated-string-function,
-        deprecated-str-translate-call,
-        deprecated-itertools-function,
-        deprecated-types-field,
-        next-method-defined,
-        dict-items-not-iterating,
-        dict-keys-not-iterating,
-        dict-values-not-iterating,
-        deprecated-operator-function,
-        deprecated-urllib-function,
-        xreadlines-attribute,
-        deprecated-sys-function,
-        exception-escape,
-        comprehension-escape
+        use-symbolic-message-instead
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -150,11 +102,11 @@ enable=c-extension-no-member
 [REPORTS]
 
 # Python expression which should return a score less than or equal to 10. You
-# have access to the variables 'error', 'warning', 'refactor', and 'convention'
-# which contain the number of messages in each category, as well as 'statement'
-# which is the total number of statements analyzed. This score is used by the
-# global evaluation report (RP0004).
-evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details.
@@ -181,7 +133,7 @@ max-nested-blocks=5
 # inconsistent-return-statements if a never returning function is called then
 # it will be considered as an explicit return statement and no message will be
 # printed.
-never-returning-functions=sys.exit
+never-returning-functions=sys.exit,argparse.parse_error
 
 
 [TYPECHECK]
@@ -197,7 +149,7 @@ contextmanager-decorators=contextlib.contextmanager
 generated-members=
 
 # Tells whether missing members accessed in mixin class should be ignored. A
-# mixin class is detected if its name ends with "mixin" (case insensitive).
+# class is considered mixin if its name matches the mixin-class-rgx option.
 ignore-mixin-members=yes
 
 # Tells whether to warn about missing members when the owner of the attribute
@@ -235,6 +187,10 @@ missing-member-hint-distance=1
 # showing a hint for a missing member.
 missing-member-max-choices=1
 
+# Regex pattern to define which classes are considered mixins ignore-mixin-
+# members is set to 'yes'
+mixin-class-rgx=.*[Mm]ixin
+
 # List of decorators that change the signature of a decorated function.
 signature-mutators=
 
@@ -260,13 +216,6 @@ max-line-length=100
 # Maximum number of lines in a module.
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no
@@ -278,14 +227,17 @@ single-line-if-stmt=no
 
 [SIMILARITIES]
 
-# Ignore comments when computing similarities.
+# Comments are removed from the similarity computation
 ignore-comments=yes
 
-# Ignore docstrings when computing similarities.
+# Docstrings are removed from the similarity computation
 ignore-docstrings=yes
 
-# Ignore imports when computing similarities.
+# Imports are removed from the similarity computation
 ignore-imports=no
+
+# Signatures are removed from the similarity computation
+ignore-signatures=no
 
 # Minimum lines number of a similarity.
 min-similarity-lines=4
@@ -297,8 +249,12 @@ min-similarity-lines=4
 max-spelling-suggestions=4
 
 # Spelling dictionary name. Available dictionaries: none. To make it work,
-# install the python-enchant package.
+# install the 'python-enchant' package.
 spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear and the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
 
 # List of comma separated words that should not be checked.
 spelling-ignore-words=
@@ -318,6 +274,145 @@ notes=FIXME,
       XXX,
       TODO
 
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
 
 [VARIABLES]
 
@@ -327,6 +422,9 @@ additional-builtins=
 
 # Tells whether unused global variables should be treated as a violation.
 allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
 
 # List of strings which can identify a callback function by name. A callback
 # name must start or end with one of those strings.
@@ -351,125 +449,19 @@ redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
 
 [STRING]
 
-# This flag controls whether the implicit-str-concat-in-sequence should
-# generate a warning on implicit string concatenation in sequences defined over
-# several lines.
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
 check-str-concat-over-line-jumps=no
-
-
-[BASIC]
-
-# Naming style matching correct argument names.
-argument-naming-style=snake_case
-
-# Regular expression matching correct argument names. Overrides argument-
-# naming-style.
-#argument-rgx=
-
-# Naming style matching correct attribute names.
-attr-naming-style=snake_case
-
-# Regular expression matching correct attribute names. Overrides attr-naming-
-# style.
-#attr-rgx=
-
-# Bad variable names which should always be refused, separated by a comma.
-bad-names=foo,
-          bar,
-          baz,
-          toto,
-          tutu,
-          tata
-
-# Naming style matching correct class attribute names.
-class-attribute-naming-style=any
-
-# Regular expression matching correct class attribute names. Overrides class-
-# attribute-naming-style.
-#class-attribute-rgx=
-
-# Naming style matching correct class names.
-class-naming-style=PascalCase
-
-# Regular expression matching correct class names. Overrides class-naming-
-# style.
-#class-rgx=
-
-# Naming style matching correct constant names.
-const-naming-style=UPPER_CASE
-
-# Regular expression matching correct constant names. Overrides const-naming-
-# style.
-#const-rgx=
-
-# Minimum line length for functions/classes that require docstrings, shorter
-# ones are exempt.
-docstring-min-length=-1
-
-# Naming style matching correct function names.
-function-naming-style=snake_case
-
-# Regular expression matching correct function names. Overrides function-
-# naming-style.
-#function-rgx=
-
-# Good variable names which should always be accepted, separated by a comma.
-good-names=i,
-           j,
-           k,
-           ex,
-           Run,
-           _
-
-# Include a hint for the correct naming format with invalid-name.
-include-naming-hint=no
-
-# Naming style matching correct inline iteration names.
-inlinevar-naming-style=any
-
-# Regular expression matching correct inline iteration names. Overrides
-# inlinevar-naming-style.
-#inlinevar-rgx=
-
-# Naming style matching correct method names.
-method-naming-style=snake_case
-
-# Regular expression matching correct method names. Overrides method-naming-
-# style.
-#method-rgx=
-
-# Naming style matching correct module names.
-module-naming-style=snake_case
-
-# Regular expression matching correct module names. Overrides module-naming-
-# style.
-#module-rgx=
-
-# Colon-delimited sets of names that determine each other's naming style when
-# the name regexes allow several styles.
-name-group=
-
-# Regular expression which should only match function or class names that do
-# not require a docstring.
-no-docstring-rgx=^_
-
-# List of decorators that produce properties, such as abc.abstractproperty. Add
-# to this list to register other decorators that produce valid properties.
-# These decorators are taken in consideration only for invalid-name.
-property-classes=abc.abstractproperty
-
-# Naming style matching correct variable names.
-variable-naming-style=snake_case
-
-# Regular expression matching correct variable names. Overrides variable-
-# naming-style.
-#variable-rgx=
 
 
 [LOGGING]
 
-# Format style used to check logging format string. `old` means using %
-# formatting, `new` is for `{}` formatting,and `fstr` is for f-strings.
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
 logging-format-style=old
 
 # Logging modules to check that the string format arguments are in logging
@@ -478,6 +470,9 @@ logging-modules=logging
 
 
 [CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,
@@ -515,18 +510,19 @@ allow-wildcard-with-all=no
 analyse-fallback-blocks=no
 
 # Deprecated modules which should not be used, separated by a comma.
-deprecated-modules=optparse,tkinter.tix
+deprecated-modules=
 
-# Create a graph of external dependencies in the given file (report RP0402 must
-# not be disabled).
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
 ext-import-graph=
 
-# Create a graph of every (i.e. internal and external) dependencies in the
-# given file (report RP0402 must not be disabled).
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
 import-graph=
 
-# Create a graph of internal dependencies in the given file (report RP0402 must
-# not be disabled).
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
 int-import-graph=
 
 # Force import order to recognize a module as part of the standard
@@ -541,6 +537,14 @@ preferred-modules=
 
 
 [DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
 
 # Maximum number of arguments for function / method.
 max-args=5

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ class Packaging(setuptools.Command):
 
 PROD_PACKAGES = [
     'filester',
-    'pyspark',
+    'pyspark~=3.2',
 ]
 
 DEV_PACKAGES = [

--- a/src/diffit/files.py
+++ b/src/diffit/files.py
@@ -9,18 +9,26 @@ from pyspark.sql.session import SparkSession
 from pyspark.sql.types import StructType
 
 
-def spark_csv_reader(spark: SparkSession, schema: StructType, csv_path: str) -> DataFrame:
+def spark_csv_reader(spark: SparkSession,
+                     schema: StructType,
+                     csv_path: str,
+                     delimiter: str = ',',
+                     header: bool = True) -> DataFrame:
     """Spark CSV reader.
+
+    Setting such as *delimiter* and *header* can be adjusted during the read.
+
+    Returns a DataFrame representation of the CSV.
 
     """
     return spark.read\
         .schema(schema)\
-        .option('delimiter', ';')\
+        .option('delimiter', delimiter)\
         .option('ignoreTrailingWhiteSpace', 'true')\
         .option('ignoreLeadingWhiteSpace', 'true')\
-        .option('header', 'false')\
-        .option('emptyValue', '')\
-        .option('quote', '\u0000')\
+        .option('header', header)\
+        .option('emptyValue', None)\
+        .option('quote', '"')\
         .csv(csv_path)
 
 
@@ -47,3 +55,26 @@ def split_dir(directory_path: str, directory_token: str) -> Union[str, None]:
             break
 
     return new_path
+
+
+def sanitise_columns(source: DataFrame, problematic_chars=',;{}()=') -> DataFrame:
+    """As the diffit engine produces a parquet output, we may need
+    to remove special characters from the source headers that do not
+    align with the parquet conventions. The column sanitise step will:
+    - convert to lower case
+    - replace spaces with under-score
+    - strip out the *problematic_char* set
+
+    Returns a new DataFrame with adjusted columns
+
+    """
+    new_columns = []
+
+    for column in source.columns:
+        column = column.lower()
+        column = column.replace(' ', '_')
+        for _char in problematic_chars:
+            column = column.replace(_char, '')
+        new_columns.append(column)
+
+    return source.toDF(*new_columns)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,18 +28,24 @@ def spark_context(request) -> pyspark.SparkContext:
 
     conf = pyspark.SparkConf()
     conf.setAppName('test')
-    conf.set('spark.executor.memory', '2g')
-    conf.set('spark.executor.cores', '2')
-    conf.set('spark.cores.max', '10')
+    conf.set('spark.driver.memory', '1g')
     conf.set('spark.ui.port', '4050')
     conf.set('spark.logConf', True)
     conf.set('spark.debug.maxToStringFields', 100)
+    conf.set('spark.sql.session.timeZone', 'UTC')
 
     _sc = pyspark.SparkContext(conf=conf)
 
     request.addfinalizer(fin)
 
     return _sc
+
+
+@pytest.fixture(scope='session')
+def spark(spark_context) -> pyspark.sql.SparkSession:
+    """Handler to the Spark session.
+    """
+    return pyspark.sql.SparkSession(spark_context)
 
 
 @pytest.fixture

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -6,11 +6,32 @@ import pyspark
 def test_spark_context(spark_context):
     """Load the Spark context fixture.
     """
-    # Given an environment that provides a Spark context (spark_context)
+    # Given an environment that provides a Spark context
+    # spark_context
 
     # then I should have a pyspark.SparkContext instance
     msg = 'conftest does not provide us a pyspark.SparkContext instance'
     assert isinstance(spark_context, pyspark.SparkContext), msg
+
+    # and the default "spark.driver.memory" should be "1g"
+    msg = 'pyspark.SparkContext "spark.driver.memory" setting error'
+    # pylint: disable=protected-access
+    assert spark_context._conf.get('spark.driver.memory') == '1g', msg
+    # pylint: enable=protected-access
+
+
+def test_spark_session(spark):
+    """Access the SparkSession
+    """
+    # Given a SparkSession
+    # spark
+
+    # when I check the PySpark version
+    received = spark.version
+
+    # then the version number should the currently supported value
+    msg = 'Supported SparkSession version error'
+    assert received.startswith('3.2'), msg
 
 
 def test_working_dir(working_dir):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -9,12 +9,13 @@ import diffit.files
 import diffit.schema
 
 
-def test_spark_csv_reader(working_dir, spark_context):
-    """Read in a custom Seek Anayltics CSV file.
+def test_spark_csv_reader_delimiter_as_semicolon(working_dir, spark):
+    """Read in a CSV file: delimited with semi-colon.
     """
-    # Given a path to CSV data
+    # Given a path to CSV data delimited with a semi-colon (";")
     path_to_csv = None
     with tempfile.NamedTemporaryFile(mode='w', dir=working_dir, delete=False) as _fh:
+        _fh.write('col01;col02\n')
         for count in range(1, 10):
             _fh.write(f'{count};col02_val0{count}\n')
         path_to_csv = _fh.name
@@ -22,22 +23,50 @@ def test_spark_csv_reader(working_dir, spark_context):
     # and a CSV schema struct context
     schema = diffit.schema.get('Dummy')
 
-    # and a Spark context
-    spark = SparkSession(spark_context)
+    # and a SparkSession
+    # spark
+
+    # and override the CSV column delimiter with a semi-colon
+    delimiter = ';'
+
+    # when I read into a Spark SQL DataFrame
+    received = diffit.files.spark_csv_reader(spark, schema, path_to_csv, delimiter)
+
+    # then I should receive content
+    msg = 'CSV semi-colon delimted Spark SQL reader DataFrame error'
+    assert received.count() == 9, msg
+
+
+def test_spark_csv_reader_delimiter_as_comma(working_dir, spark):
+    """Read in a custom CSV file: delimiter as comma.
+    """
+    # Given a path to CSV data delimited with a comma (",")
+    path_to_csv = None
+    with tempfile.NamedTemporaryFile(mode='w', dir=working_dir, delete=False) as _fh:
+        _fh.write('col01,col02\n')
+        for count in range(1, 10):
+            _fh.write(f'{count},col02_val0{count}\n')
+        path_to_csv = _fh.name
+
+    # and a CSV schema struct context
+    schema = diffit.schema.get('Dummy')
+
+    # and a SparkSession
+    # spark
 
     # when I read into a Spark SQL DataFrame
     received = diffit.files.spark_csv_reader(spark, schema, path_to_csv)
 
     # then I should receive content
-    msg = 'CSV Spark SQL reader DataFrame error'
+    msg = 'CSV comma delimted Spark SQL reader DataFrame error'
     assert received.count() == 9, msg
 
 
-def test_spark_parquet_reader(working_dir, spark_context):
-    """Read in a custom Seek Anayltics Parquet file.
+def test_spark_parquet_reader(working_dir, spark):
+    """Read in a custom Parquet file.
     """
-    # Given a Spark context
-    spark = SparkSession(spark_context)
+    # Given a SparkSession
+    # spark
 
     # and a path to parquet data
     data =[
@@ -98,3 +127,46 @@ def test_split_dir_no_token_match():
     # then I should received None
     msg = 'Directory split against unknown part should return None'
     assert not received, msg
+
+
+def test_sanitise_columns(spark):
+    """Santise columns that are acceptable parquet.
+    """
+    # Given a SparkSession
+    # spark
+
+    # and a path to parquet data
+    data =[
+        ('James', '', 'Smith', '36636', 'M', 3000),
+    ]
+    columns = ['firstname', 'middlename', 'lastname', 'dob', 'gender', 'salary']
+    _df = spark.createDataFrame(data, columns)
+
+    # when I santise the DataFrame columns
+    received = diffit.files.sanitise_columns(_df)
+
+    # then I should receive content
+    msg = 'Sanitising good parquet columns should not change the columns names'
+    assert received.columns == columns, msg
+
+
+def test_sanitise_columns_rejected_characters(spark):
+    """Santise columns that do not align with parquet naming convention.
+    """
+    # Given a SparkSession
+    # spark
+
+    # and a path to parquet data
+    data =[
+        ('James', '', 'Smith', '36636', 'M', 3000),
+    ]
+    columns = ['First name;', 'Middle, name', '{lastname}', '(DOB)', 'gender=', 'salary']
+    _df = spark.createDataFrame(data, columns)
+
+    # when I santise the DataFrame columns
+    received = diffit.files.sanitise_columns(_df)
+
+    # then I should receive content
+    expected = ['first_name', 'middle_name', 'lastname', 'dob', 'gender', 'salary']
+    msg = 'Sanitising parquet columns should change the columns names'
+    assert received.columns == expected, msg


### PR DESCRIPTION
# Summary
* `spark_csv_reader()` function now supports parameterised `delimiter` and `header` that customise the Spark reader
* new `sanitise_columns()` functions to align with parquet naming conventions

## Pre-Review Checks
- [ ] `make tests` completes successfully
- [ ] [Reviewed and commented](https://leeorengel.com/review-comment-your-pull-requests/) on PR